### PR TITLE
Remove extraneous `use` statement (#4193)

### DIFF
--- a/listings/ch14-more-about-cargo/listing-14-07/add/adder/src/main.rs
+++ b/listings/ch14-more-about-cargo/listing-14-07/add/adder/src/main.rs
@@ -1,5 +1,3 @@
-use add_one;
-
 fn main() {
     let num = 10;
     println!("Hello, world! {num} plus one is {}!", add_one::add_one(num));

--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -149,11 +149,10 @@ Cargo doesn’t assume that crates in a workspace will depend on each other, so
 we need to be explicit about the dependency relationships.
 
 Next, let’s use the `add_one` function (from the `add_one` crate) in the
-`adder` crate. Open the _adder/src/main.rs_ file and add a `use` line at the
-top to bring the new `add_one` library crate into scope. Then change the `main`
+`adder` crate. Open the _adder/src/main.rs_ file and change the `main`
 function to call the `add_one` function, as in Listing 14-7.
 
-<Listing number="14-7" file-name="adder/src/main.rs" caption="Using the `add_one` library crate from the `adder` crate">
+<Listing number="14-7" file-name="adder/src/main.rs" caption="Using the `add_one` library crate in the `adder` crate">
 
 ```rust,ignore
 {{#rustdoc_include ../listings/ch14-more-about-cargo/listing-14-07/add/adder/src/main.rs}}


### PR DESCRIPTION
In Listing 14-7 of Chapter 14, the `use add_one;` statement is redundant and can be removed. Before the Rust 2018 edition, this statement was required to bring the `add_one` crate into scope, so it likely got missed during refactorings from that transition.

By removing this line, the code becomes more concise and reflects the current best practices for using external crates in Rust.

Issue #4186

---------