### PR TITLE
remove text-direction from book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,7 +5,6 @@
 title = "The Rust Programming Language"
 authors = ["Steve Klabnik", "Carol Nichols", "Chris Krycho", "Contributions from the Rust Community"]
 language = "fa"
-text-direction = "rtl"
 
 [output.html]
 additional-css = ["ferris.css", "theme/2018-edition.css", "theme/semantic-notes.css", "theme/listing.css", "theme/custom.css"]


### PR DESCRIPTION
setting the language to "fa" should make the book rtl

As far as I know `text-direction = "rtl"` is now unnecessary as the `language = "fa"` setting should already sets the book to `rtl`.  https://github.com/rust-lang/mdBook/blob/3052fe38270bb370dcf54009d450c5395537d975/src/config.rs#L466


Currently this is the only mdboik I am aware of that uses this option. See https://mdbooks.code-maven.com/text-direction

Before I propose the change to the `mdbook` project, I'd like to ask you to verify that indeed the  `language = "fa"` setting is enough for you as well.
