### PR TITLE
Set ordered lists to use Arabic-Indic numerals

### DIFF
--- a/theme/custom.css
+++ b/theme/custom.css
@@ -6,6 +6,10 @@ code {
     text-align: left;
 }
 
+ol {
+    list-style-type: arabic-indic;
+}
+
 .content {
     text-align: justify;
     direction: rtl;


### PR DESCRIPTION
This CSS rule modifies the appearance of **ordered lists (`<ol>`)** by changing the numbering style.

- **`list-style-type: arabic-indic;`** sets the list item numbers to **Arabic-Indic numerals** (۰,۱,۲,۳,...) instead of the default Western Arabic numerals (0, 1, 2, 3, …).
- This is useful for **localization** or when the document content is in a language that uses Arabic-Indic numerals, such as Persian or Arabic.

With this CSS, the rendered lists would show:

<div dir="rtl">

١. مورد اول
٢. مورد دوم
٣. مورد سوم

</div>

For example, the changes affect [chapter 18.3](./src/ch18-03-oo-design-patterns.md)